### PR TITLE
Remove `neo_version_range`

### DIFF
--- a/src/assets/template/interpolated/build.gradle
+++ b/src/assets/template/interpolated/build.gradle
@@ -99,7 +99,6 @@ tasks.withType(ProcessResources).configureEach {
             minecraft_version      : minecraft_version,
             minecraft_version_range: minecraft_version_range,
             neo_version            : neo_version,
-            neo_version_range      : neo_version_range,
 {{ #before_1_21_5 }}
             loader_version_range   : loader_version_range,
 {{ /before_1_21_5 }}

--- a/src/assets/template/interpolated/gradle.properties
+++ b/src/assets/template/interpolated/gradle.properties
@@ -27,8 +27,6 @@ minecraft_version={{ minecraft_version }}
 minecraft_version_range={{ minecraft_version_range }}
 # The Neo version must agree with the Minecraft version to get a valid artifact
 neo_version={{ neo_version }}
-# The Neo version range can use any version of Neo as bounds
-neo_version_range={{ neo_version_range }}
 {{ #before_1_21_5 }}
 # The loader version range can only use the major version of FML as bounds
 loader_version_range={{ loader_version_range }}

--- a/src/assets/template/special/neoforge.mods.toml
+++ b/src/assets/template/special/neoforge.mods.toml
@@ -77,7 +77,7 @@ config="${mod_id}.mixins.json"
     # Optional field describing why the dependency is required or why it is incompatible
     # reason="..."
     # The version range of the dependency
-    versionRange="${neo_version_range}" #mandatory
+    versionRange="[${neo_version},)" #mandatory
     # An ordering relationship for the dependency.
     # BEFORE - This mod is loaded BEFORE the dependency
     # AFTER - This mod is loaded AFTER the dependency

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -98,7 +98,6 @@ function generateInterpolated(
     minecraft_version: settings.minecraftVersion,
     minecraft_version_range: versions.minecraftVersionRange,
     neo_version: versions.neoForgeVersion,
-    neo_version_range: versions.neoForgeVersionRange,
     loader_version_range: versions.loaderVersionRange,
     mod_id: settings.modId,
     mod_name: settings.modName,

--- a/src/generator/versions.ts
+++ b/src/generator/versions.ts
@@ -36,7 +36,6 @@ export interface ComputedVersions {
   parchmentMappingsVersion: string;
   minecraftVersionRange: string;
   neoForgeVersion: string;
-  neoForgeVersionRange: string;
   loaderVersionRange: string;
 }
 
@@ -73,7 +72,6 @@ export async function fetchVersions(
     parchmentMappingsVersion: versions[1].parchmentMappingsVersion,
     minecraftVersionRange: `[${settings.minecraftVersion}]`,
     neoForgeVersion: versions[2],
-    neoForgeVersionRange: `[${versions[2]},)`,
     // TODO: this is kinda useless, shouldn't we remove it altogether?
     loaderVersionRange: `[1,)`,
   };


### PR DESCRIPTION
Removes the `neo_version_range` variable and replaces it with `[${neo_version},)`. This is to avoid the newcomer of issue of updating Neo but forgetting to update the version range accordingly.

------------------
Preview URL: https://pr-29.neoforged-mod-generator-previews.pages.dev