### PR TITLE
Use npm ci

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,7 +17,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build website
         run: npm run build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Upload artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Download npm dependencies
-        run: npm install
+        run: npm ci
       - name: Generate mod template
         run: >
           npm run run -- generate


### PR DESCRIPTION
Uses npm ci instead of install to get deps from package lock.

From sci:
> As said in https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci, npm ci is preferred in CI/CD environments to perform a clean install without any automatic additions of missing or incompatible dependencies.

------------------
Preview URL: https://pr-32.neoforged-mod-generator-previews.pages.dev