### PR TITLE
Get the correct latest neo version

### DIFF
--- a/src/generator/versions.ts
+++ b/src/generator/versions.ts
@@ -48,7 +48,7 @@ export async function fetchVersions(
   minecraftVersions?: string[],
 ): Promise<ComputedVersions> {
   const mcVersion = parseMinecraftVersion(settings.minecraftVersion);
-  const neoForgePrefix = `${mcVersion.minor}.${mcVersion.patch}`;
+  const neoForgePrefix = `${mcVersion.minor}.${mcVersion.patch}.`;
 
   if (!minecraftVersions) {
     minecraftVersions = await fetchMinecraftVersions();


### PR DESCRIPTION
Closes #33 

Filters the correct neo version by adding a `.` to the end of the neo prefix.

------------------
Preview URL: https://pr-34.neoforged-mod-generator-previews.pages.dev