### PR TITLE
Exclude runs directory from version control

### DIFF
--- a/src/assets/template/raw/.gitignore
+++ b/src/assets/template/raw/.gitignore
@@ -35,6 +35,8 @@ bin/
 ### Minecraft Modding ###
 run/
 !**/src/**/run/
+runs/
+!**/src/**/runs/
 **/src/generated/**/.cache/
 repo/
 !**/src/**/repo/


### PR DESCRIPTION
This PR fixes #54 by excluding the `runs` directory, the default directory used by NeoGradle for run configurations, from version control in the same manner as `run` (used by ModDevGradle).



------------------
Preview URL: https://pr-55.neoforged-mod-generator-previews.pages.dev