### PR TITLE
Change working directory for NG runs to 'run/'

### DIFF
--- a/src/assets/template/special/ng_block.gradle
+++ b/src/assets/template/special/ng_block.gradle
@@ -18,6 +18,8 @@ runs {
         // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
         systemProperty 'forge.logging.console.level', 'debug'
 
+        workingDirectory project.layout.projectDirectory.dir('run').dir(name)
+
         modSource project.sourceSets.main
     }
 


### PR DESCRIPTION
This PR fixes #54 by changing the working directory for NeoGradle-based generated projects to `run/`, which aligns with the conventional directory used by other plugins such as ModDevGradle.

This was suggested in #55 as an alternative solution to the issue.

------------------
Preview URL: https://pr-56.neoforged-mod-generator-previews.pages.dev